### PR TITLE
Adds missing prefix in the Music SHACL file

### DIFF
--- a/shacl/music_shacl.ttl
+++ b/shacl/music_shacl.ttl
@@ -1,5 +1,6 @@
 PREFIX : <http://stardog.com/tutorial/>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 :NameShape a sh:Shape ;
    sh:property [


### PR DESCRIPTION
Hi, I found a missing prefix in the Music SHACL. It does not prevent the tutorial from being completed, however when running validation against this shape graph with other tooling, like Jena, it will be treated as an error.